### PR TITLE
feat: only generate output image when input was changed

### DIFF
--- a/resources/python/live-painting/main.py
+++ b/resources/python/live-painting/main.py
@@ -239,6 +239,9 @@ def main(pipe, input_image_path, output_image_path, shutdown_event):
     strength = 0.99
     guidance_scale = None
 
+    # When was the input image last modified
+    last_modified_time = None
+
     # Queue to hold parameters received from stdin
     params_queue = queue.Queue()
 
@@ -257,9 +260,17 @@ def main(pipe, input_image_path, output_image_path, shutdown_event):
                 seed = parameters.get("seed", seed)
                 strength = parameters.get("strength", strength)
                 guidance_scale = parameters.get("guidance_scale", guidance_scale)
-                print(f"Updated parameters {parameters}")
         except queue.Empty:
             pass  # No new parameters, proceed with the existing ones
+
+        # Get the current modified time of the input image
+        current_modified_time = os.path.getmtime(input_image_path)
+
+        if current_modified_time != last_modified_time:
+            last_modified_time = current_modified_time
+        else:
+            # Skip this iteration since the input image has not changed
+            continue
 
         # Only generate an image if the prompt is not empty
         if prompt is not None and prompt.strip():


### PR DESCRIPTION
## Motivation

* In order to be faster and reduce CPU overhead, we only generate the output image when the input image actually was changed