### PR TITLE
chore: sematic-release on protected branch

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Semantic release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BLIBLA_SEMANTIC_RELEASE }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: windows-latest-l
+    runs-on: windows-latest
     if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
     permissions:
       contents: write # to be able to publish a GitHub release
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Motivation

* [Use a custom PAT in order to create a release on a protected-branch](https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch)
* Use "windows-latest" runner as we don't need the custom "windows-latest-l" runner (reduce cost)